### PR TITLE
Protect trip editing

### DIFF
--- a/app/handlers/trips_handler.py
+++ b/app/handlers/trips_handler.py
@@ -8,11 +8,33 @@ def select_all_trips():
     else:
         return {"message": "No trips found!"}
     
-def create_trip(user_id: int, trip_id: str, trip_is_group: bool):
+def create_trip(user_id: int, trip_id: str, trip_is_group: bool, is_save_operation: bool = False):
     # Validate trip_type
     if trip_is_group not in [True, False]:
         return {"message": "Invalid trip type! Must be 'individual' or 'group'"}
+    
+    # Check if user is already a participant in this trip
+    existing_response = supabase.table("user_trips").select("*").eq("user_id", user_id).eq("trip_id", trip_id).execute()
+    if existing_response.data and len(existing_response.data) > 0:
+        print(f"User {user_id} is already a participant in trip {trip_id}")
         
+        if is_save_operation:
+            # For save operations, update the existing record
+            print(f"Updating existing participant record for user {user_id} in trip {trip_id}")
+            update_response = supabase.table("user_trips").update({
+                "status": "group" if trip_is_group else "individual",
+                "joined_trip_at": datetime.now().isoformat()
+            }).eq("user_id", user_id).eq("trip_id", trip_id).execute()
+            
+            if update_response.data:
+                return update_response.data[0]
+            else:
+                return {"message": "Failed to update participant record!"}
+        else:
+            # For creation operations, reject duplicates
+            return {"message": "User is already a participant in this trip!"}
+        
+    # Create new participant record if user is not already a participant
     response = supabase.table("user_trips").insert({
         "user_id": user_id, 
         "trip_id": trip_id, 
@@ -84,8 +106,10 @@ def reject_invitation(user_id: int, trip_id: str):
         return {"message": "Rejection failed!"}
     
 def trip_participants(trip_id: str):
+    print("--------------------------------")
     response = supabase.table("user_trips").select("*").eq("trip_id", trip_id).neq("status", "pending").execute()
     if response.data:
+        print(response.data)
         return response.data
     else:
         return {"message": "No participants found!"}

--- a/app/routes/trips_router.py
+++ b/app/routes/trips_router.py
@@ -15,7 +15,7 @@ async def get_all_trips():
 async def save_trip(body: TripSaveBody, request: Request):
     """Create a new trip in the database."""
     user = get_current_user(request)
-    return create_trip(user.id, body.trip_id, body.is_group)
+    return create_trip(user.id, body.trip_id, body.is_group, is_save_operation=True)
 
 @router.get("/user")
 @require_auth
@@ -65,3 +65,12 @@ async def get_trip_participants(trip_id: str, request: Request):
     """Get all participants of a trip."""
     user = get_current_user(request)
     return trip_participants(trip_id)
+
+@router.get("/participants-count/{trip_id}")
+async def get_trip_participants_count(trip_id: str):
+    """Get the count of participants for a trip (no authentication required)."""
+    participants = trip_participants(trip_id)
+    if isinstance(participants, list):
+        return {"count": len(participants), "has_participants": len(participants) > 0}
+    else:
+        return {"count": 0, "has_participants": False}


### PR DESCRIPTION
This pull request introduces enhancements to the trip management functionality, including support for updating participant records during save operations, a new endpoint for retrieving participant counts, and additional logging for debugging purposes.

### Enhancements to trip creation and saving:
* `create_trip` in `app/handlers/trips_handler.py`: Added a new `is_save_operation` parameter to handle save operations. If a user is already a participant in a trip, the function updates their record instead of creating a duplicate. Otherwise, it rejects duplicate creation attempts.
* `save_trip` in `app/routes/trips_router.py`: Updated to pass the `is_save_operation=True` flag when saving trips, ensuring the correct behavior for save operations.

### New functionality for participant management:
* `get_trip_participants_count` in `app/routes/trips_router.py`: Introduced a new endpoint to retrieve the count of participants for a trip, including a flag indicating whether there are any participants. This endpoint does not require authentication.

### Debugging improvements:
* `trip_participants` in `app/handlers/trips_handler.py`: Added logging to print participant data for debugging purposes.